### PR TITLE
set tensorflow-probability version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'optax<0.1.8; python_version < "3.9.0"',
         "tqdm",
         "rich",
-        "tensorflow_probability",
+        'tensorflow_probability <= "0.23.0"',
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
## Description
current tensorflow-probability has some backwards-incompatible changes

## Motivation and Context
closes #29
by default `tensorflow-probability==0.24.0` (latest as of current date) will be installed, which is incompatible right now for a number of different reasons. Pinning this in `setup.py` so a compatible version is installed by default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Other checklist items aren't applicable

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line
